### PR TITLE
Added a parameter to keep SSL certs intact and updated .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ Policyfile.lock.json
 
 # IDE
 .idea/
+*.iml

--- a/templates/default/sc@.service.erb
+++ b/templates/default/sc@.service.erb
@@ -19,7 +19,8 @@ ExecStart = /usr/local/bin/sc \
 --logfile - \
 --pidfile "/tmp/sauceconnect_%i.pid" \
 --se-port "%i" \
---no-remove-colliding-tunnels
+--no-remove-colliding-tunnels \
+-B all
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
By default, quoting SC docs, "Sauce Connect executes a type of "man-in-the-middle" interception of encrypted test traffic through SSL bumping..."; this theoretically allows better caching but in our case it might be interfering with Duo. The option to disable this behaviour was enabled on the original installation, so re-enabling in the current setup

Updated .gitignore to exclude IntelliJ Idea-specific files